### PR TITLE
fix(tsconfig): invalid option name

### DIFF
--- a/Topics/05. Setup-and-Architecture/demos/setup-webpack/tsconfig.json
+++ b/Topics/05. Setup-and-Architecture/demos/setup-webpack/tsconfig.json
@@ -7,7 +7,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "noImplicitAny": true,
-    "suppressImplicitAnyInexErrors": true
+    "suppressImplicitAnyIndexErrors": true
   },
   "compileOnSave": false,
   "exclude": [

--- a/Topics/06. Ng-Modules/demos/modules-visibility/tsconfig.json
+++ b/Topics/06. Ng-Modules/demos/modules-visibility/tsconfig.json
@@ -7,7 +7,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "noImplicitAny": true,
-    "suppressImplicitAnyInexErrors": true
+    "suppressImplicitAnyIndexErrors": true
   },
   "compileOnSave": false,
   "exclude": [

--- a/Topics/07. Components/demos/content/tsconfig.json
+++ b/Topics/07. Components/demos/content/tsconfig.json
@@ -7,7 +7,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "noImplicitAny": true,
-    "suppressImplicitAnyInexErrors": true
+    "suppressImplicitAnyIndexErrors": true
   },
   "compileOnSave": false,
   "exclude": [

--- a/Topics/07. Components/demos/demo-application/tsconfig.json
+++ b/Topics/07. Components/demos/demo-application/tsconfig.json
@@ -7,7 +7,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "noImplicitAny": true,
-    "suppressImplicitAnyInexErrors": true
+    "suppressImplicitAnyIndexErrors": true
   },
   "compileOnSave": false,
   "exclude": [

--- a/Topics/08. Data-Binding/demos/data-binding/tsconfig.json
+++ b/Topics/08. Data-Binding/demos/data-binding/tsconfig.json
@@ -7,7 +7,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "noImplicitAny": true,
-    "suppressImplicitAnyInexErrors": true
+    "suppressImplicitAnyIndexErrors": true
   },
   "compileOnSave": false,
   "exclude": [

--- a/Workshops/2. Angular/top-movies/top-movies_skeleton/tsconfig.json
+++ b/Workshops/2. Angular/top-movies/top-movies_skeleton/tsconfig.json
@@ -7,7 +7,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "noImplicitAny": true,
-    "suppressImplicitAnyInexErrors": true
+    "suppressImplicitAnyIndexErrors": true
   },
   "compileOnSave": false,
   "exclude": [


### PR DESCRIPTION
There is a typo in the `suppressImplicitAny` option
Referring to https://angular.io/docs/ts/latest/guide/typescript-configuration.html