### PR TITLE
fix(top_movies_skeleton/package) missing dependency - ng2-bootstrap

### DIFF
--- a/Workshops/2. Angular/top-movies/top-movies_skeleton/package.json
+++ b/Workshops/2. Angular/top-movies/top-movies_skeleton/package.json
@@ -38,6 +38,7 @@
     "http-server": "^0.9.0",
     "ie-shim": "^0.1.0",
     "jquery": "^3.1.1",
+    "ng2-bootstrap": "^1.1.16-10",
     "rxjs": "5.0.0-beta.12",
     "zone.js": "~0.6.26"
   },


### PR DESCRIPTION
There was error during starting the dev server due to
`ERROR in [default] ...Cannot find module 'ng2-bootstrap/ng2-bootstrap'.`
Added the missing dependency to package.json

Module `ng2-bootstrap/ng2-bootstrap` is imported in [app.module.ts](https://github.com/TelerikAcademy/Angular-2/blob/master/Workshops/2.%20Angular/top-movies/top-movies_skeleton/app/app.module.ts#L7)